### PR TITLE
update main window gui.

### DIFF
--- a/BinaryParserApp/MainWindow.xaml
+++ b/BinaryParserApp/MainWindow.xaml
@@ -1,11 +1,12 @@
 ﻿<Window x:Class="BinaryParserApp.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="バイナリ解析" Height="160" Width="500">
+        Title="{Binding TitleText}" Height="200" Width="560">
     <Grid Margin="20">
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="1*"/>
+            <RowDefinition Height="1*"/>
+            <RowDefinition Height="1*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
@@ -14,15 +15,17 @@
         </Grid.ColumnDefinitions>
 
         <!-- JSON設定ファイルパス -->
-        <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,10,10">設定ファイル(JSON)</TextBlock>
-        <TextBox Grid.Row="0" Grid.Column="1" Name="JsonPathTextBox" Margin="0,0,0,10" Text="{Binding JsonFilePath.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+        <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center">設定ファイルパス(JSON)</TextBlock>
+        <TextBox Grid.Row="0" Grid.Column="1" Name="JsonPathTextBox" Margin="4" VerticalContentAlignment="Center" Text="{Binding JsonFilePath.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
         <!-- BINファイルパス -->
-        <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,10,10">バイナリファイル(BIN)</TextBlock>
-        <TextBox Grid.Row="1" Grid.Column="1" Name="BinPathTextBox" Margin="0,0,0,10" Text="{Binding BinFilePath.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+        <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center">解析対象入力※</TextBlock>
+        <TextBox Grid.Row="1" Grid.Column="1" Name="BinPathTextBox"  Margin="4" VerticalContentAlignment="Center" Text="{Binding BinFilePath.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+
+        <TextBlock Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" VerticalAlignment="Center">※バイナリファイルパス or HEX文字列を入力してください 例) 12-AB-CD / 12ABCD / 12_AB_CD</TextBlock>
 
         <!-- 変換ボタン -->
-        <Button Grid.Row="2" Grid.Column="1" Command="{Binding ConvertCommand}"
+        <Button Grid.Row="3" Grid.Column="1" Command="{Binding ConvertCommand}"
                 Name="ConvertButton" Content="変換" Width="100" HorizontalAlignment="Right"/>
         
     </Grid>

--- a/BinaryParserApp/ViewModel/MainWindowViewModel.cs
+++ b/BinaryParserApp/ViewModel/MainWindowViewModel.cs
@@ -16,6 +16,7 @@ namespace BinaryParserApp.ViewModel
     public class MainWindowViewModel
     {
         private readonly IWindowService _windowService;
+        public string TitleText { get; private set; }
 
         // JSON設定ファイルパス
         public ReactiveProperty<string> JsonFilePath { get; set; }
@@ -29,7 +30,7 @@ namespace BinaryParserApp.ViewModel
         public MainWindowViewModel(IWindowService windowService)
         {
             _windowService = windowService;
-
+            TitleText = CreateAppTitle();
             // 設定から前回値を復元
             JsonFilePath = new ReactiveProperty<string>(Properties.Settings.Default.JsonFilePath);
             BinFilePath = new ReactiveProperty<string>(Properties.Settings.Default.BinFilePath);
@@ -42,6 +43,20 @@ namespace BinaryParserApp.ViewModel
 
             ConvertCommand.Subscribe(async _ => await ConvertAsync());
         }
+
+        /// <summary>
+        /// タイトル文字列の作成 例)「BinaryParserApp ver1.0.1.0」
+        /// </summary>
+        private string? CreateAppTitle()
+        {
+            var version = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version;
+            if (version == null)
+            {
+                return "BinaryParserApp";
+            }
+            return $"BinaryParserApp ver{version.Major}.{version.Minor}.{version.Build}.{version.Revision}";
+        }
+
         private async Task ConvertAsync()
         {
             try


### PR DESCRIPTION
# 内容
- タイトル変更(バージョン表記)
- 入力がファイルパス/生HEX文字列の両方に対応したのにGUIを対応

# AI生成メモ
ウィンドウタイトルのバインディングとサイズ変更

MainWindow.xamlでウィンドウのタイトルを固定文字列からバインディングされたプロパティに変更し、ウィンドウサイズを拡大しました。グリッドの行定義を追加し、テキストブロックの内容とマージンを調整、変換ボタンの位置も変更しました。

MainWindowViewModel.csでは、アプリケーションのタイトルを生成する`CreateAppTitle`メソッドを追加し、`TitleText`プロパティを導入しました。これにより、ウィンドウのタイトルが動的に設定されるようになりました。